### PR TITLE
Remove leading underscore in test's expected_output_file and expect compiled script to have a legacy pragma if cjsx pragma is used

### DIFF
--- a/test/dummy/app/assets/javascripts/car.js
+++ b/test/dummy/app/assets/javascripts/car.js
@@ -3,13 +3,13 @@
 
   Car = React.createClass({
     render: function() {
-      var _ref;
+      var ref;
       return React.createElement("div", {
         "doors": 4.,
         "date": Date.now() * 2,
         "data-top-down": "yep",
         "checked": true
-      }, "Car", React.createElement("hr", null), React.createElement("hr", null), React.createElement("p", null, ((_ref = this.props) != null ? _ref.color : void 0) || 'none'));
+      }, "Car", React.createElement("hr", null), React.createElement("hr", null), React.createElement("p", null, ((ref = this.props) != null ? ref.color : void 0) || 'none'));
     }
   });
 

--- a/test/dummy/app/assets/javascripts/car_with_legacy_pragma.js
+++ b/test/dummy/app/assets/javascripts/car_with_legacy_pragma.js
@@ -1,0 +1,23 @@
+(function() {
+  /** @jsx React.DOM */;
+  var Car;
+
+  Car = React.createClass({
+    render: function() {
+      var ref;
+      return React.createElement("div", {
+        "doors": 4.,
+        "date": Date.now() * 2,
+        "data-top-down": "yep",
+        "checked": true
+      }, "Car", React.createElement("hr", null), React.createElement("hr", null), React.createElement("p", null, ((ref = this.props) != null ? ref.color : void 0) || 'none'));
+    }
+  });
+
+  $(function() {
+    return React.renderComponent(React.createElement(Car, {
+      "color": "red"
+    }), $('<div />').appendTo($('body')).get(0));
+  });
+
+}).call(this);

--- a/test/sprockets-coffee-react_test.rb
+++ b/test/sprockets-coffee-react_test.rb
@@ -7,7 +7,7 @@ class SprocketsCoffeeReactTest < ActionDispatch::IntegrationTest
 
   test ".js.coffee with pragma" do
     get "/assets/car1.js"
-    assert_equal expected_output_file.read, @response.body.to_s
+    assert_equal epxected_output_file_with_legacy_pragma.read, @response.body.to_s
     assert_response :success
   end
 
@@ -35,6 +35,10 @@ class SprocketsCoffeeReactTest < ActionDispatch::IntegrationTest
 
   def expected_output_file
     File.open(example_file_path '/dummy/app/assets/javascripts/car.js')
+  end
+
+  def epxected_output_file_with_legacy_pragma
+    File.open(example_file_path '/dummy/app/assets/javascripts/car_with_legacy_pragma.js')
   end
 
   def example_file_path(filename)

--- a/test/sprockets-coffee-react_test.rb
+++ b/test/sprockets-coffee-react_test.rb
@@ -7,7 +7,7 @@ class SprocketsCoffeeReactTest < ActionDispatch::IntegrationTest
 
   test ".js.coffee with pragma" do
     get "/assets/car1.js"
-    assert_equal epxected_output_file_with_legacy_pragma.read, @response.body.to_s
+    assert_equal expected_output_file_with_legacy_pragma.read, @response.body.to_s
     assert_response :success
   end
 
@@ -37,7 +37,7 @@ class SprocketsCoffeeReactTest < ActionDispatch::IntegrationTest
     File.open(example_file_path '/dummy/app/assets/javascripts/car.js')
   end
 
-  def epxected_output_file_with_legacy_pragma
+  def expected_output_file_with_legacy_pragma
     File.open(example_file_path '/dummy/app/assets/javascripts/car_with_legacy_pragma.js')
   end
 


### PR DESCRIPTION
Since CoffeeScript v1.9.1 leading underscore in generated variables
Was removed by pull request https://github.com/jashkenas/coffeescript/pull/3821