### PR TITLE
Sprockets 4 compatibility

### DIFF
--- a/lib/sprockets/coffee-react-script.rb
+++ b/lib/sprockets/coffee-react-script.rb
@@ -23,5 +23,16 @@ module Sprockets
       end
     end
 
+    def self.call(input)
+      filename = input[:source_path] || input[:filename]
+      data = input[:data]
+      if filename.to_s =~ /\.coffee\.cjsx/
+        ::CoffeeReact.transform(data)
+      elsif filename.to_s =~ CJSX_EXTENSION
+        ::CoffeeScript.compile(::CoffeeReact.transform(data))
+      else
+        data
+      end
+    end
   end
 end

--- a/lib/sprockets/coffee-react-script.rb
+++ b/lib/sprockets/coffee-react-script.rb
@@ -24,11 +24,11 @@ module Sprockets
     end
 
     def self.call(input)
-      filename = input[:source_path] || input[:filename]
+      filename = (input[:source_path] || input[:filename]).to_s
       data = input[:data]
-      if filename.to_s =~ /\.coffee\.cjsx/
+      if filename =~ /\.coffee(\.source-.*)?\.cjsx/
         ::CoffeeReact.transform(data)
-      elsif filename.to_s =~ CJSX_EXTENSION
+      elsif filename =~ CJSX_EXTENSION
         ::CoffeeScript.compile(::CoffeeReact.transform(data))
       else
         data

--- a/lib/sprockets/coffee-react.rb
+++ b/lib/sprockets/coffee-react.rb
@@ -21,10 +21,8 @@ module Sprockets
     end
 
     def self.install(environment = ::Sprockets)
-      environment.register_preprocessor 'application/javascript', Sprockets::CoffeeReact
-      environment.register_postprocessor 'application/javascript', Sprockets::CoffeeReactPostprocessor
-      environment.register_engine '.cjsx', Sprockets::CoffeeReactScript
-      environment.register_engine '.js.cjsx', Sprockets::CoffeeReactScript
+      environment.register_mime_type 'application/x-cjsx',extensions: ['.cjsx', '.js.cjsx']
+      environment.register_transformer 'application/x-cjsx', 'application/javascript', Sprockets::CoffeeReactScript
     end
   end
 end

--- a/lib/sprockets/coffee-react/engine.rb
+++ b/lib/sprockets/coffee-react/engine.rb
@@ -15,10 +15,8 @@ if defined?(Rails)
         end
 
         def configure_env(env)
-          env.register_preprocessor 'application/javascript', Sprockets::CoffeeReact
-          env.register_postprocessor 'application/javascript', Sprockets::CoffeeReactPostprocessor
-          env.register_engine '.cjsx', Sprockets::CoffeeReactScript
-          env.register_engine '.js.cjsx', Sprockets::CoffeeReactScript
+          env.register_mime_type 'application/x-cjsx', extensions: ['.cjsx', '.js.cjsx']
+          env.register_transformer 'application/x-cjsx', 'application/javascript', Sprockets::CoffeeReactScript
         end
       end
     end


### PR DESCRIPTION
Updates SprocketsCoffeeReact to use the Transformer interface as described in https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md

I don't think this allows source maps to work yet though.